### PR TITLE
Gradle構成にKtlintを追加 #5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,45 +1,57 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-	id("org.springframework.boot") version "3.2.3"
-	id("io.spring.dependency-management") version "1.1.4"
+    id("org.springframework.boot") version "3.2.3"
+    id("io.spring.dependency-management") version "1.1.4"
+    id("org.jlleitschuh.gradle.ktlint") version "12.1.0"
 
-	kotlin("jvm") version "1.9.22"
-	kotlin("plugin.spring") version "1.9.22"
-	kotlin("plugin.jpa") version "1.9.22"
+    kotlin("jvm") version "1.9.22"
+    kotlin("plugin.spring") version "1.9.22"
+    kotlin("plugin.jpa") version "1.9.22"
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 allprojects {
-	val axonVersion = "4.9.3"
+    val axonVersion = "4.9.3"
 
-	group = "inaba"
-	version = "0.0.1-SNAPSHOT"
+    group = "inaba"
+    version = "0.0.1-SNAPSHOT"
 
-	apply(plugin = "kotlin")
+    apply(plugin = "kotlin")
+    apply(plugin = "org.jlleitschuh.gradle.ktlint")
 
-	repositories {
-		mavenCentral()
-	}
+    repositories {
+        mavenCentral()
+    }
 
-	tasks.withType<KotlinCompile> {
-		kotlinOptions {
-			freeCompilerArgs += "-Xjsr305=strict"
-			jvmTarget = "21"
-		}
-	}
+    tasks.withType<KotlinCompile> {
+        kotlinOptions {
+            freeCompilerArgs += "-Xjsr305=strict"
+            jvmTarget = "21"
+        }
+    }
 
-	tasks.withType<Test> {
-		useJUnitPlatform()
-	}
+    tasks.withType<Test> {
+        useJUnitPlatform()
+    }
 
-	dependencies {
-		implementation(platform("org.axonframework:axon-bom:${axonVersion}"))
-		implementation("io.github.oshai:kotlin-logging-jvm:5.1.0")
-		implementation("com.michael-bull.kotlin-result:kotlin-result:2.0.0")
-	}
+    dependencies {
+        implementation(platform("org.axonframework:axon-bom:$axonVersion"))
+        implementation("io.github.oshai:kotlin-logging-jvm:5.1.0")
+        implementation("com.michael-bull.kotlin-result:kotlin-result:2.0.0")
+    }
+
+    // Ktlintの設定値
+    configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
+        // testディレクトリをコーディング規約チェックから除外する
+        filter {
+            exclude { element ->
+                element.file.path.contains("test")
+            }
+        }
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,16 +2,12 @@ rootProject.name = "inaba"
 
 include(
     "common",
-
     "catalog:catalog-api",
     "catalog:catalog-service",
-
     "identity:identity-api",
     "identity:identity-service",
-
     "order:order-api",
     "order:order-service",
-
     "basket:basket-api",
-    "basket:basket-service"
+    "basket:basket-service",
 )


### PR DESCRIPTION
Gradleの構成ファイルに[Ktlint](https://github.com/JLLeitschuh/ktlint-gradle)を追加しました。
実行は手動です。

変更点が多い理由は字下げをTabから4スペースに置き換えたためです。

Intellij IDEAの実行の構成に追加できます。
代表的なタスクはcheckとktlintFormatです。
checkでコードスタイルのチェックができます。
ktlintFormatでコードのフォーマットができます。
![image](https://github.com/azarasi1226/inaba-backend/assets/12002158/432eaf1c-7267-4a7f-8b27-f96b21ef6ef4)
